### PR TITLE
Default the failure limit to 1 as zero is an invalid value

### DIFF
--- a/src/Handler/Factory/MemcachedFactory.php
+++ b/src/Handler/Factory/MemcachedFactory.php
@@ -102,7 +102,7 @@ class MemcachedFactory extends AbstractFactory
         $memcached->setOptions([
             Memcached::OPT_BINARY_PROTOCOL        => $binary,
             Memcached::OPT_LIBKETAMA_COMPATIBLE   => $options->getBoolean('consistent_hash'),
-            Memcached::OPT_SERVER_FAILURE_LIMIT   => $options->getInt('server_failure_limit'),
+            Memcached::OPT_SERVER_FAILURE_LIMIT   => $options->getInt('server_failure_limit', 1), // See #3
             Memcached::OPT_NUMBER_OF_REPLICAS     => $options->getInt('number_of_replicas'),
             Memcached::OPT_RANDOMIZE_REPLICA_READ => $options->getBoolean('randomize_replica_read'),
             Memcached::OPT_REMOVE_FAILED_SERVERS  => $options->getBoolean('remove_failed_servers'),


### PR DESCRIPTION
Fixes: bolt/bolt#7357

The default of zero throws an invalid argument error despite the Memcached docs indicating that this should be a valid value.